### PR TITLE
Cache fix attempt

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -49,7 +49,7 @@ def summary():
   return jsonify(calculations_by_day)
 
 @app.route('/running-gap', methods=['GET'])
-@cache.cached(timeout=5 * 60)
+@cache.cached(timeout=1 * 60)
 def running_gap():
   start = (datetime.now() - timedelta(days=1)).strftime('%Y-%m-%d')
   end = datetime.now().strftime('%Y-%m-%d')

--- a/api/app.py
+++ b/api/app.py
@@ -4,6 +4,7 @@ from flask_caching import Cache
 from config import CACHE_CONFIG
 from datetime import datetime, timedelta
 
+from utils import calculate_date_cache_key
 from tweets import get_date_range, group_by_day, get_all_calculations, get_longest_gap, get_current_gap
 from dmi_tcat import fetch_tweets_for_date
 
@@ -13,15 +14,6 @@ CORS(app)
 app.config.from_mapping(CACHE_CONFIG)
 cache = Cache(app)
 
-def calculate_date_cache_key(date):
-  app.logger.debug(f'Calculating cache key for {date}')
-  if datetime.now().date() == datetime.strptime(date, '%Y-%m-%d').date():
-    period = int(int(datetime.strftime(datetime.now(), '%M')) / 15)
-    calculated_cache_key = datetime.strftime(datetime.now(), f'%Y-%m-%d %H {period}')
-  else:
-    calculated_cache_key = date
-  app.logger.debug(f'CALCULATED CACHE KEY: {calculated_cache_key}')
-  return calculated_cache_key
 
 @app.route('/<date>', methods=['GET'])
 @cache.cached(make_cache_key=calculate_date_cache_key)
@@ -31,11 +23,8 @@ def index(date):
 
   return jsonify(tweets=tweets, calculations=calculations)
 
-def get_summary_cache_key():
-  return datetime.now().strftime('%Y-%m-%d')
-
 @app.route('/summary', methods=['GET'])
-@cache.cached(make_cache_key=get_summary_cache_key)
+@cache.cached(make_cache_key=calculate_date_cache_key)
 def summary():
   start, end = get_date_range()
   tweets = fetch_tweets_for_date(start, end)

--- a/api/app.py
+++ b/api/app.py
@@ -4,7 +4,7 @@ from flask_caching import Cache
 from config import CACHE_CONFIG
 from datetime import datetime, timedelta
 
-from tweets import get_date_range, group_by_day, get_all_calculations, get_longest_gap
+from tweets import get_date_range, group_by_day, get_all_calculations, get_longest_gap, get_current_gap
 from dmi_tcat import fetch_tweets_for_date
 
 app = Flask(__name__)
@@ -49,14 +49,17 @@ def summary():
   return jsonify(calculations_by_day)
 
 @app.route('/running-gap', methods=['GET'])
-@cache.cached(timeout=15 * 60)
+@cache.cached(timeout=5 * 60)
 def running_gap():
   start = (datetime.now() - timedelta(days=1)).strftime('%Y-%m-%d')
   end = datetime.now().strftime('%Y-%m-%d')
 
   tweets = fetch_tweets_for_date(start, end)
 
-  return jsonify(get_longest_gap(tweets))
+  return jsonify({
+    'longest_gap': get_longest_gap(tweets),
+    'current_gap': get_current_gap(tweets)
+  })
 
 if __name__ == '__main__':
    app.run(host='0.0.0.0', debug=True)

--- a/api/config.py
+++ b/api/config.py
@@ -1,5 +1,6 @@
 import os
 from dotenv import load_dotenv
+from logging.config import dictConfig
 
 load_dotenv()
 
@@ -11,3 +12,19 @@ CACHE_CONFIG = {
     'CACHE_TYPE': 'simple',
     'CACHE_DEFAULT_TIMEOUT': 30 * 24 * 60 * 60, # 30 days
 }
+
+dictConfig({
+    'version': 1,
+    'formatters': {'default': {
+        'format': '[%(asctime)s] %(levelname)s in %(module)s: %(message)s',
+    }},
+    'handlers': {'wsgi': {
+        'class': 'logging.StreamHandler',
+        'stream': 'ext://flask.logging.wsgi_errors_stream',
+        'formatter': 'default'
+    }},
+    'root': {
+        'level': 'INFO',
+        'handlers': ['wsgi']
+    }
+})

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,4 @@ flask_cors
 requests
 python-dotenv
 Flask-Caching
+freezegun

--- a/api/test.py
+++ b/api/test.py
@@ -1,5 +1,41 @@
 import unittest
+import logging
+import sys
+
+from freezegun import freeze_time
+
 from tweets import _calculate_time
+from utils import calculate_date_cache_key
+from datetime import datetime
+
+# logger = logging.getLogger()
+# logger.level = logging.DEBUG
+# logger.addHandler(logging.StreamHandler(sys.stdout))
+
+class TestCacheKeyGeneration(unittest.TestCase):
+  def test_returns_date_for_past_dates(self):
+    self.assertEqual(calculate_date_cache_key("2019-12-25"), "2019-12-25")
+    self.assertEqual(calculate_date_cache_key("2020-08-01"), "2020-08-01")
+    self.assertEqual(calculate_date_cache_key("2020-10-03"), "2020-10-03")
+    self.assertEqual(calculate_date_cache_key("2019-12-25"), "2019-12-25")
+    self.assertEqual(calculate_date_cache_key("1980-05-04"), "1980-05-04")
+
+  def test_returns_date_with_period_for_today(self):
+    with freeze_time("2012-01-14 12:08:11"):
+      self.assertEqual(calculate_date_cache_key("2012-01-14"), "2012-01-14 12 0")
+    with freeze_time("2012-01-14 12:21:11"):
+      self.assertEqual(calculate_date_cache_key("2012-01-14"), "2012-01-14 12 1")
+    with freeze_time("2012-01-14 12:44:59"):
+      self.assertEqual(calculate_date_cache_key("2012-01-14"), "2012-01-14 12 2")
+    with freeze_time("2012-01-14 12:45:01"):
+      self.assertEqual(calculate_date_cache_key("2012-01-14"), "2012-01-14 12 3")
+    with freeze_time("2012-01-14 13:08:11"):
+      self.assertEqual(calculate_date_cache_key("2012-01-14"), "2012-01-14 13 0")
+
+  def test_returns_date_with_period_for_tomorrow(self):
+    with freeze_time("2012-01-14 23:58:11"):
+      self.assertEqual(calculate_date_cache_key("2012-01-15"), "2012-01-14 23 3")
+
 
 class TestCalculateTime(unittest.TestCase):
     def test_empty(self):

--- a/api/tweets.py
+++ b/api/tweets.py
@@ -86,16 +86,6 @@ def get_longest_gap(tweets):
 
 def get_current_gap(tweets):
   return (datetime.now() - datetime.fromisoformat(tweets[-1]["created_at"])).seconds
-  # gap = 0
-  # current_tweet_time = datetime.fromisoformat(tweets[0]["created_at"])
-  # previous_tweet_time = None
-  # for tweet in tweets[1:]:
-  #   previous_tweet_time = current_tweet_time
-  #   current_tweet_time = datetime.fromisoformat(tweet["created_at"])
-  #   gap = max((current_tweet_time - previous_tweet_time).seconds, gap)
-
-  # return gap
-
 
 def get_all_calculations(tweets):
   calculations = _get_counts(tweets)

--- a/api/tweets.py
+++ b/api/tweets.py
@@ -73,8 +73,11 @@ def _calculate_time(tweets):
 
   return duration
 
+def get_current_gap(tweets):
+  return (datetime.now() - datetime.fromisoformat(tweets[-1]["created_at"])).seconds
+
 def get_longest_gap(tweets):
-  gap = 0
+  gap = get_current_gap(tweets)
   current_tweet_time = datetime.fromisoformat(tweets[0]["created_at"])
   previous_tweet_time = None
   for tweet in tweets[1:]:
@@ -83,9 +86,6 @@ def get_longest_gap(tweets):
     gap = max((current_tweet_time - previous_tweet_time).seconds, gap)
 
   return gap
-
-def get_current_gap(tweets):
-  return (datetime.now() - datetime.fromisoformat(tweets[-1]["created_at"])).seconds
 
 def get_all_calculations(tweets):
   calculations = _get_counts(tweets)

--- a/api/tweets.py
+++ b/api/tweets.py
@@ -84,6 +84,18 @@ def get_longest_gap(tweets):
 
   return gap
 
+def get_current_gap(tweets):
+  return (datetime.now() - datetime.fromisoformat(tweets[-1]["created_at"])).seconds
+  # gap = 0
+  # current_tweet_time = datetime.fromisoformat(tweets[0]["created_at"])
+  # previous_tweet_time = None
+  # for tweet in tweets[1:]:
+  #   previous_tweet_time = current_tweet_time
+  #   current_tweet_time = datetime.fromisoformat(tweet["created_at"])
+  #   gap = max((current_tweet_time - previous_tweet_time).seconds, gap)
+
+  # return gap
+
 
 def get_all_calculations(tweets):
   calculations = _get_counts(tweets)

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+import logging
+
+logger = logging.getLogger(__name__)
+
+def calculate_date_cache_key(date):
+  logger.info(f'Calculating cache key for {date}')
+  if datetime.now().date() == datetime.strptime(date, '%Y-%m-%d').date():
+    period = int(int(datetime.strftime(datetime.now(), '%M')) / 15)
+    calculated_cache_key = datetime.strftime(datetime.now(), f'%Y-%m-%d %H {period}')
+  else:
+    calculated_cache_key = date
+  logger.info(f'CALCULATED CACHE KEY: {calculated_cache_key}')
+  return calculated_cache_key
+

--- a/api/utils.py
+++ b/api/utils.py
@@ -5,7 +5,7 @@ logger = logging.getLogger(__name__)
 
 def calculate_date_cache_key(date):
   logger.info(f'Calculating cache key for {date}')
-  if datetime.now().date() == datetime.strptime(date, '%Y-%m-%d').date():
+  if datetime.now().date() <= datetime.strptime(date, '%Y-%m-%d').date():
     period = int(int(datetime.strftime(datetime.now(), '%M')) / 15)
     calculated_cache_key = datetime.strftime(datetime.now(), f'%Y-%m-%d %H {period}')
   else:


### PR DESCRIPTION
This does very little with the actual code, the only functional change to it is changing a `==` to `<=` [here](https://github.com/danesjenovdan/twito/commit/62699db80983429f955017c628aaa087f3b617b5#diff-1927a2a7260bf138319644bceb09095e47b82f13b79db71504801f8705c00394R8), other changes are just a bit of refactoring and an attempt to cover the bug with a test.

If I understand correctly, the issue is the following:
- `calculate_date_cache_key` should return a key that changes every 15 minutes for today's date
- at 0:30 Slovenian time, it's actually 23:30 the previous day on server (UTC), so the special case in the function isn't triggered
- it returns a cache key with just the date, which never changes
- DMI-TCAT returns empty results and we cache them using the long-term-just-date key

The condition adjustment above should solve the problem by also generating 15-min-period cache keys if the requested date is "tomorrow" from the perspective of the server.

But I'm still a bit confused by this - as far as I understand `calculate_date_cache_key` is run every time a request is made, no exception. Wouldn't this imply that the bug I described only happens in that one-hour period between midnight and 1:00? After that, the server should once again start calculating the key correctly (differently every 15 minutes).