### PR TITLE
Rewrite caching logic using forced_update

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -4,3 +4,5 @@ requests
 python-dotenv
 Flask-Caching
 freezegun
+pytz
+ipdb

--- a/api/test.py
+++ b/api/test.py
@@ -5,36 +5,118 @@ import sys
 from freezegun import freeze_time
 
 from tweets import _calculate_time
-from utils import calculate_date_cache_key
+from utils import DateCacheInfo, SummaryCacheInfo
 from datetime import datetime
 
-# logger = logging.getLogger()
-# logger.level = logging.DEBUG
-# logger.addHandler(logging.StreamHandler(sys.stdout))
 
-class TestCacheKeyGeneration(unittest.TestCase):
-  def test_returns_date_for_past_dates(self):
-    self.assertEqual(calculate_date_cache_key("2019-12-25"), "2019-12-25")
-    self.assertEqual(calculate_date_cache_key("2020-08-01"), "2020-08-01")
-    self.assertEqual(calculate_date_cache_key("2020-10-03"), "2020-10-03")
-    self.assertEqual(calculate_date_cache_key("2019-12-25"), "2019-12-25")
-    self.assertEqual(calculate_date_cache_key("1980-05-04"), "1980-05-04")
+class TestSummaryCacheInfo(unittest.TestCase):
+  def test_forces_update_on_date_change(self):
+    # Setting a random future date first to get our starting point.
+    with freeze_time('2022-01-14T10:00Z'):
+      self.assertEqual(SummaryCacheInfo.should_force_update(), True)
 
-  def test_returns_date_with_period_for_today(self):
-    with freeze_time("2012-01-14 12:08:11"):
-      self.assertEqual(calculate_date_cache_key("2012-01-14"), "2012-01-14 12 0")
-    with freeze_time("2012-01-14 12:21:11"):
-      self.assertEqual(calculate_date_cache_key("2012-01-14"), "2012-01-14 12 1")
-    with freeze_time("2012-01-14 12:44:59"):
-      self.assertEqual(calculate_date_cache_key("2012-01-14"), "2012-01-14 12 2")
-    with freeze_time("2012-01-14 12:45:01"):
-      self.assertEqual(calculate_date_cache_key("2012-01-14"), "2012-01-14 12 3")
-    with freeze_time("2012-01-14 13:08:11"):
-      self.assertEqual(calculate_date_cache_key("2012-01-14"), "2012-01-14 13 0")
+    # Still the same day, so the cache is valid still
+    with freeze_time('2022-01-14T15:00Z'):
+      self.assertEqual(SummaryCacheInfo.should_force_update(), False)
+    with freeze_time('2022-01-14T20:00Z'):
+      self.assertEqual(SummaryCacheInfo.should_force_update(), False)
 
-  def test_returns_date_with_period_for_tomorrow(self):
-    with freeze_time("2012-01-14 23:58:11"):
-      self.assertEqual(calculate_date_cache_key("2012-01-15"), "2012-01-14 23 3")
+    # Still the same day in UTC, but already next day in Slovenia
+    with freeze_time('2022-01-14T23:30Z'):
+      self.assertEqual(SummaryCacheInfo.should_force_update(), True)
+    with freeze_time('2022-01-15T00:30Z'):
+      self.assertEqual(SummaryCacheInfo.should_force_update(), False)
+
+  def test_knows_about_DST(self):
+    # Moving to a random future date first to get our starting point. It's
+    # August, so Slovenia should be in DST, which is UTC+2.
+    with freeze_time('2022-08-14T10:00Z'):
+      self.assertEqual(SummaryCacheInfo.should_force_update(), True)
+    with freeze_time('2022-08-14T15:59Z'):
+      self.assertEqual(SummaryCacheInfo.should_force_update(), False)
+    with freeze_time('2022-08-14T21:59Z'):
+      self.assertEqual(SummaryCacheInfo.should_force_update(), False)
+
+    # This is one minute past midnight in Slovenia
+    with freeze_time('2022-08-14T22:01Z'):
+      self.assertEqual(SummaryCacheInfo.should_force_update(), True)
+    with freeze_time('2022-08-14T23:01Z'):
+      self.assertEqual(SummaryCacheInfo.should_force_update(), False)
+    with freeze_time('2022-08-15T00:01Z'):
+      self.assertEqual(SummaryCacheInfo.should_force_update(), False)
+
+  def test_resets_updated_time_when_updating(self):
+    initial_date_string = '2022-08-14 16:01+00:00'
+
+    with freeze_time(initial_date_string):
+      self.assertEqual(SummaryCacheInfo.should_force_update(), True)
+      # Above call returned True, so last_update should match current datetime
+      self.assertEqual(SummaryCacheInfo.last_update, datetime.fromisoformat(initial_date_string))
+
+    with freeze_time('2022-08-14 20:01+00:00'):
+      self.assertEqual(SummaryCacheInfo.should_force_update(), False)
+      # Above call returned False, so last_update should be unchanged
+      self.assertEqual(SummaryCacheInfo.last_update, datetime.fromisoformat(initial_date_string))
+
+
+class TestDateCacheInfo(unittest.TestCase):
+  @freeze_time('2022-01-14')
+  def test_does_not_force_update_for_past_dates(self):
+      # All initial calls return True because there is no last update set yet,
+      # but from there on, past dates consistently return False
+
+      self.assertEqual(DateCacheInfo.should_force_update('2022-01-01'), True)
+      self.assertEqual(DateCacheInfo.should_force_update('2022-01-01'), False)
+
+      self.assertEqual(DateCacheInfo.should_force_update('2020-01-01'), True)
+      self.assertEqual(DateCacheInfo.should_force_update('2020-01-01'), False)
+      self.assertEqual(DateCacheInfo.should_force_update('2020-01-01'), False)
+
+      self.assertEqual(DateCacheInfo.should_force_update('1989-04-16'), True)
+      self.assertEqual(DateCacheInfo.should_force_update('1989-04-16'), False)
+      self.assertEqual(DateCacheInfo.should_force_update('1989-04-16'), False)
+      self.assertEqual(DateCacheInfo.should_force_update('1989-04-16'), False)
+
+  @freeze_time('2022-01-15T07:12Z')
+  def test_forces_update_every_15_minutes_for_today(self):
+      # As before, first call returns True and sets the last update time
+      self.assertEqual(DateCacheInfo.should_force_update('2022-01-15'), True)
+
+      # Now, the call will return False
+      self.assertEqual(DateCacheInfo.should_force_update('2022-01-15'), False)
+
+      # Still False 14 minutes later
+      with freeze_time('2022-01-15T07:26Z'):
+        self.assertEqual(DateCacheInfo.should_force_update('2022-01-15'), False)
+
+      # And then True 16 minutes later
+      with freeze_time('2022-01-15T07:28Z'):
+        self.assertEqual(DateCacheInfo.should_force_update('2022-01-15'), True)
+
+      # And so on
+      with freeze_time('2022-01-15T07:40Z'):
+        self.assertEqual(DateCacheInfo.should_force_update('2022-01-15'), False)
+      with freeze_time('2022-01-15T07:42Z'):
+        self.assertEqual(DateCacheInfo.should_force_update('2022-01-15'), False)
+      with freeze_time('2022-01-15T07:44Z'):
+        self.assertEqual(DateCacheInfo.should_force_update('2022-01-15'), True)
+
+  @freeze_time('2022-01-15T07:12Z')
+  def test_forces_update_for_past_date_with_old_data(self):
+      # Last time we fetched fresh data was just before midnight _in Slovenia_
+      # on January 14th, so one hour earlier in UTC.
+      DateCacheInfo.last_updates['2022-01-14'] = datetime.fromisoformat('2022-01-14 22:46+00:00')
+
+      # Today is January 15th, it's 7 in the morning (set in decorator). If
+      # someone tries to get data January 14th, we update the cache because even
+      # though the date itself is already "yesterday", our last update was also
+      # yesterday and Ivan could have tweeted in those last 15 minutes before
+      # midnight.
+      self.assertEqual(DateCacheInfo.should_force_update('2022-01-14'), True)
+
+      # But now that the above call triggered a refresh, an identical one should
+      # return False
+      self.assertEqual(DateCacheInfo.should_force_update('2022-01-14'), False)
 
 
 class TestCalculateTime(unittest.TestCase):

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,15 +1,60 @@
-from datetime import datetime
+from datetime import datetime, timedelta, tzinfo
+from pytz import timezone, country_timezones
 import logging
 
 logger = logging.getLogger(__name__)
 
-def calculate_date_cache_key(date):
-  logger.info(f'Calculating cache key for {date}')
-  if datetime.now().date() <= datetime.strptime(date, '%Y-%m-%d').date():
-    period = int(int(datetime.strftime(datetime.now(), '%M')) / 15)
-    calculated_cache_key = datetime.strftime(datetime.now(), f'%Y-%m-%d %H {period}')
-  else:
-    calculated_cache_key = date
-  logger.info(f'CALCULATED CACHE KEY: {calculated_cache_key}')
-  return calculated_cache_key
+SLOVENIAN_TIMEZONE = timezone('CET')
+TODAYS_CACHE_PERIOD = 15 # minutes
 
+class DateCacheInfo:
+  last_updates = {}
+
+  @staticmethod
+  def get_end_of_day(date_string):
+    (year, month, day) = [int(date_part) for date_part in date_string.split('-')]
+    last_second_of_day = datetime(year, month, day, hour=23, minute=59, second=59, tzinfo=SLOVENIAN_TIMEZONE)
+
+    return last_second_of_day
+
+  @classmethod
+  def date_passed_in_slovenia(self, date_string):
+    return self.get_end_of_day(date_string) < datetime.now(tz=SLOVENIAN_TIMEZONE)
+
+  @classmethod
+  def should_force_update(self, date):
+    date_passed_in_slo = self.date_passed_in_slovenia(date)
+    last_updated_after_date = self.get_last_update(date) > self.get_end_of_day(date)
+
+    if date_passed_in_slo and last_updated_after_date:
+      return False
+
+    time_since_last_update = datetime.now(tz=SLOVENIAN_TIMEZONE) - self.get_last_update(date)
+
+    if time_since_last_update > timedelta(minutes=TODAYS_CACHE_PERIOD):
+      self.set_last_update(date)
+      return True
+
+    return False
+
+  @classmethod
+  def get_last_update(self, date_string):
+    return self.last_updates.get(date_string, datetime.fromtimestamp(0, tz=SLOVENIAN_TIMEZONE))
+
+  @classmethod
+  def set_last_update(self, date_string):
+    self.last_updates[date_string] = datetime.now(tz=SLOVENIAN_TIMEZONE)
+
+
+class SummaryCacheInfo:
+  last_update = None
+
+  @classmethod
+  def should_force_update(self):
+    now = datetime.now(tz=SLOVENIAN_TIMEZONE)
+
+    if not self.last_update or self.last_update.day != now.day:
+      self.last_update = now
+      return True
+
+    return False

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,1 +1,1 @@
-VITE_API_URL=https://api.twito.si/
+VITE_API_URL=http://localhost:5000/


### PR DESCRIPTION
As @metalcamp suggested, I tried to update our caching logic and covered it with tests as well as I could. We don't rely on changing `cache_key` anymore, but rather on passing an explicit `forced_update` whenever we think it's applicable.