### PR TITLE
Configure nginx for client routing

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,3 +14,6 @@ FROM nginx:alpine
 
 # copy built files from the 'build' container into the nginx container
 COPY --from=build dist /usr/share/nginx/html
+
+# copy custom nginx config to support client-side routing
+COPY ./nginx.conf /etc/nginx/conf.d/default.conf

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,8 @@
+server {
+  listen       80;
+  location / {
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    try_files $uri $uri/ /index.html =404;
+  }
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,12 +1,7 @@
-import _ from 'lodash'
 import vue from '@vitejs/plugin-vue'
 
-// import templateStrings from './templateStrings.json'
-
 export default {
-  plugins: [
-    vue(),
-  ],
+  plugins: [vue()],
   optimizeDeps: {
     include: [
       'lodash-es/camelCase',
@@ -16,5 +11,4 @@ export default {
       'lodash-es/mapValues',
     ],
   },
-  indexHtmlTransforms: [({ code }) => _.template(code)(templateStrings)],
 }


### PR DESCRIPTION
This PR should enable support for subpage URLs with a date at the end such as [skoraj.twito.si/2021-05-23](https://skoraj.twito.si/2021-05-23) by pointing them all to `index.html` and letting `vue-router` handle it.